### PR TITLE
Fix new path syntax description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ As it only makes sense to reference composite actions, the `docker://` form isn'
 As you frequently want to include local actions, `actions-includes` extends the 
 `{action-name}` syntax to also support:
 
- - `/{name}` - Local action under `./.github/actions/includes/{name}`.
+ - `/{name}` - Local action under `./.github/includes/actions/{name}`.
 
 This is how composite actions should have worked.
 


### PR DESCRIPTION
The readme does not reflect the actual location the code checks for the included action